### PR TITLE
#80: Fix reports for models having multiple process definitions

### DIFF
--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/MethodCoverage.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/MethodCoverage.java
@@ -78,6 +78,7 @@ public class MethodCoverage implements AggregatedCoverage {
      * Retrieves the coverage percentage for all process definitions deployed
      * with the method.
      */
+    @Override
     public double getCoveragePercentage() {
 
         // Aggregate element collections
@@ -122,6 +123,7 @@ public class MethodCoverage implements AggregatedCoverage {
      * with the method.
      * @param processDefinitionKey
      */
+    @Override
     public double getCoveragePercentage(String processDefinitionKey) {
 
         ProcessCoverage processCoverage = processDefinitionKeyToProcessCoverage.get(processDefinitionKey);
@@ -249,6 +251,7 @@ public class MethodCoverage implements AggregatedCoverage {
     /**
      * Retrieves a set of element IDs of covered flow nodes of the process definition identified by the passed key.
      */
+    @Override
     public Set<String> getCoveredFlowNodeIds(String processDefinitionKey) {
 
         final ProcessCoverage processCoverage = processDefinitionKeyToProcessCoverage.get(processDefinitionKey);
@@ -273,6 +276,7 @@ public class MethodCoverage implements AggregatedCoverage {
     /**
      * Retrieves a set of element IDs of sequence flows of the process definition identified by the passed key.
      */
+    @Override
     public Set<String> getCoveredSequenceFlowIds(String processDefinitionKey) {
 
         final ProcessCoverage processCoverage = processDefinitionKeyToProcessCoverage.get(processDefinitionKey);
@@ -299,6 +303,7 @@ public class MethodCoverage implements AggregatedCoverage {
      * definitions having the same process definition key but coming from separate BPMNs
      * may be returned.
      */
+    @Override
     public Set<ProcessDefinition> getProcessDefinitions() {
 
         final Set<ProcessDefinition> processDefinitions = new TreeSet<ProcessDefinition>(
@@ -307,7 +312,9 @@ public class MethodCoverage implements AggregatedCoverage {
                     // Avoid removing process definitions with the same key, but coming from different BPMNs.
                     @Override
                     public int compare(ProcessDefinition o1, ProcessDefinition o2) {
-                        return o1.getResourceName().compareTo(o2.getResourceName());
+                        final String id1 = o1.getResourceName() + "#" + o1.getKey();
+                        final String id2 = o2.getResourceName() + "#" + o2.getKey();
+                        return id1.compareTo(id2);
                     }
                 });
 

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/ProcessCoverage.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/model/ProcessCoverage.java
@@ -9,7 +9,6 @@ import java.util.logging.Logger;
 
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
-import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.camunda.bpm.model.bpmn.instance.FlowNode;
 import org.camunda.bpm.model.bpmn.instance.SequenceFlow;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
@@ -62,11 +61,11 @@ public class ProcessCoverage {
 
         this.processDefinition = processDefinition;
 
-        final BpmnModelInstance modelInstance = processEngine.getRepositoryService().getBpmnModelInstance(
-                getProcessDefinitionId());
+        final ModelElementInstance modelInstance = processEngine.getRepositoryService().getBpmnModelInstance(
+                getProcessDefinitionId()).getModelElementById(processDefinition.getKey());
 
-        definitionFlowNodes = getExecutableFlowNodes(modelInstance.getModelElementsByType(FlowNode.class));
-        definitionSequenceFlows = getExecutableSequenceNodes(modelInstance.getModelElementsByType(SequenceFlow.class));
+        definitionFlowNodes = getExecutableFlowNodes(modelInstance.getChildElementsByType(FlowNode.class));
+        definitionSequenceFlows = getExecutableSequenceNodes(modelInstance.getChildElementsByType(SequenceFlow.class));
 
     }
 

--- a/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/util/CoverageReportUtil.java
+++ b/core/src/main/java/org/camunda/bpm/extension/process_test_coverage/util/CoverageReportUtil.java
@@ -3,7 +3,6 @@ package org.camunda.bpm.extension.process_test_coverage.util;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
 import org.camunda.bpm.extension.process_test_coverage.junit.rules.CoverageTestRunState;
 import org.camunda.bpm.extension.process_test_coverage.model.AggregatedCoverage;
@@ -96,6 +95,11 @@ public class CoverageReportUtil {
         final Set<ProcessDefinition> processDefinitions = coverage.getProcessDefinitions();
         for (ProcessDefinition processDefinition : processDefinitions) {
 
+            final double coveragePercentage = coverage.getCoveragePercentage(processDefinition.getKey());
+            if (coveragePercentage == 0.0) {
+                continue; // skip untested process definitions of BPMNs holding multiple process definitions
+            }
+            
             try {
 
                 // Assemble data
@@ -113,7 +117,7 @@ public class CoverageReportUtil {
                         coveredSequenceFlowIds,
                         reportDirectory + '/' + reportName,
                         processDefinition.getKey(),
-                        coverage.getCoveragePercentage(processDefinition.getKey()),
+                        coveragePercentage,
                         testClass,
                         testName);
 


### PR DESCRIPTION
1. MethodCoverage: Use definition resource name AND process definition key for determining all process definitions
2. ProcessCoverage: Filter definitionFlowNodes and definitionSequenceFlows according the process definition key to fix the percentage
3. CoverageReportUtil: Do not generate method empty method reports

Ad 3: The coverage tool cannot know which process has been tested as part of a specific test method. So the easiest way is to drop all reports having a coverage of 0%. This might lead to missing reports if the coverage is really 0% but doing process tests is not meant to build test methods having 0% coverage ;-). Since the class coverage is always correct (and might break a build if below the requested coverage) I decided that missing test method reports is fine since this should only happen on creating new test methods.