### PR TITLE
#121 add possibility to configure builder for extension with process engine configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Either use `@ExtendWith`
 public class MyProcessTest
 ```
 or `@RegisterExtension`
+
+If you register the extension on a non-static field, no class coverage and therefore no report will be generated. This is due to the fact, that an instance of the extension will be created per test method.
+
 ```java
 @RegisterExtension
 static ProcessEngineCoverageExtension extension = ProcessEngineCoverageExtension

--- a/examples/junit5/src/test/java/org/camunda/bpm/extension/process_test_coverage/examples/OrderProcessTest.java
+++ b/examples/junit5/src/test/java/org/camunda/bpm/extension/process_test_coverage/examples/OrderProcessTest.java
@@ -5,12 +5,16 @@ import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.extension.process_test_coverage.junit5.ProcessEngineCoverageExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.camunda.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 @ExtendWith(ProcessEngineCoverageExtension.class)
 @Deployment(resources = "order-process.bpmn")
 public class OrderProcessTest {
+
+//    @RegisterExtension
+//    public static ProcessEngineCoverageExtension extension = ProcessEngineCoverageExtension.builder().build();
 
     @Test
     public void shouldExecuteHappyPath() {

--- a/examples/junit5/src/test/java/org/camunda/bpm/extension/process_test_coverage/examples/OrderProcessTest.java
+++ b/examples/junit5/src/test/java/org/camunda/bpm/extension/process_test_coverage/examples/OrderProcessTest.java
@@ -5,7 +5,6 @@ import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.extension.process_test_coverage.junit5.ProcessEngineCoverageExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.camunda.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
@@ -14,7 +13,8 @@ import static org.camunda.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 public class OrderProcessTest {
 
 //    @RegisterExtension
-//    public static ProcessEngineCoverageExtension extension = ProcessEngineCoverageExtension.builder().build();
+//    public static ProcessEngineCoverageExtension extension = ProcessEngineCoverageExtension.builder(
+//            new ProcessCoverageInMemProcessEngineConfiguration().setHistory(ProcessEngineConfiguration.HISTORY_FULL)).build();
 
     @Test
     public void shouldExecuteHappyPath() {

--- a/extension/junit5/src/main/kotlin/org/camunda/bpm/extension/process_test_coverage/junit5/ProcessEngineCoverageExtension.kt
+++ b/extension/junit5/src/main/kotlin/org/camunda/bpm/extension/process_test_coverage/junit5/ProcessEngineCoverageExtension.kt
@@ -59,6 +59,8 @@ class ProcessEngineCoverageExtension(
      */
     private val testMethodNameToCoverageConditions: MutableMap<String, MutableList<Condition<Double>>> = mutableMapOf()
 
+    private var suiteInitialized = false
+
     override fun postProcessTestInstance(testInstance: Any?, context: ExtensionContext) {
         super.postProcessTestInstance(testInstance, context)
         initializeListeners()
@@ -70,7 +72,7 @@ class ProcessEngineCoverageExtension(
     override fun beforeTestExecution(context: ExtensionContext) {
         super.beforeTestExecution(context)
         if (isRelevantTestMethod()) {
-            if (!context.isSuiteInitialized()) {
+            if (!suiteInitialized) {
                 initializeSuite(context)
             }
             // method name is set only on test methods (not on classes or suites)
@@ -102,7 +104,7 @@ class ProcessEngineCoverageExtension(
         coverageCollector.createSuite(Suite(suiteId, context.requiredTestClass.name))
         coverageCollector.setExcludedProcessDefinitionKeys(excludedProcessDefinitionKeys)
         coverageCollector.activateSuite(suiteId)
-        context.suiteInitialized()
+        suiteInitialized = true
     }
 
     /**
@@ -302,14 +304,6 @@ class ProcessEngineCoverageExtension(
     }
 
 }
-
-fun ExtensionContext.isSuiteInitialized(): Boolean =
-        this.root.getStore(ExtensionContext.Namespace.create(ProcessEngineExtension::class.java))
-                .getOrDefault(this.requiredTestClass.name, Boolean::class.java, false)
-
-fun ExtensionContext.suiteInitialized() =
-        this.root.getStore(ExtensionContext.Namespace.create(ProcessEngineExtension::class.java))
-                .put(this.requiredTestClass.name, true)
 
 fun Double.checkPercentage() =
     if (0 > this || this > 1) {


### PR DESCRIPTION
Builder for extension can be retrieved with a function that takes the process engine configuration as a parameter.
This has to be a ProcessCoverageInMemProcessEngineConfiguration, a SpringProcessWithCoverageEngineConfiguration or another process engine configuration, which has to be initialized with ProcessCoverageConfigurator.initializeProcessCoverageExtensions(this);