### PR TITLE
Build the libraries based on Java 8

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -19,8 +19,10 @@ jobs:
           - 'windows-latest'
           - 'macos-latest'
         jdk:
+          - '8'
           - '11'
-          - '17' # no official support yet by Camunda
+          - '15'
+          #- '17' # no official support yet by Camunda
         camunda-version:
           - '7.16' # 2021
           - '7.15'

--- a/extension/report-generator/src/main/java/org/camunda/bpm/extension/process_test_coverage/util/CoverageReportUtil.java
+++ b/extension/report-generator/src/main/java/org/camunda/bpm/extension/process_test_coverage/util/CoverageReportUtil.java
@@ -47,7 +47,7 @@ public class CoverageReportUtil {
 
         try {
             final String report = generateHtml(result);
-            Files.createDirectories(Path.of(reportDirectory));
+            Files.createDirectories(Paths.get(reportDirectory));
             writeToFile(reportDirectory + "/report.html", report);
         } catch (IOException | URISyntaxException e) {
             throw new RuntimeException("Unable to create HTML report.", e);
@@ -62,7 +62,7 @@ public class CoverageReportUtil {
         final String reportDirectory = getReportDirectoryPath(suite.getName());
 
         try {
-            Files.createDirectories(Path.of(reportDirectory));
+            Files.createDirectories(Paths.get(reportDirectory));
             writeToFile(reportDirectory + "/report.json", result);
         } catch (final IOException ex) {
             throw new RuntimeException("Unable to create JSON report.", ex);
@@ -78,7 +78,7 @@ public class CoverageReportUtil {
     }
 
     private static void writeToFile(final String filePath, final String json) throws IOException {
-        Files.writeString(Path.of(filePath), json);
+        Files.writeString(Paths.get(filePath), json);
     }
 
     private static void installReportDependencies(final String reportDirectory) {
@@ -130,7 +130,7 @@ public class CoverageReportUtil {
 
     private static void copyFolder(Path source, Path target)
             throws IOException {
-        Files.walkFileTree(source, new SimpleFileVisitor<>() {
+        Files.walkFileTree(source, new SimpleFileVisitor<Path>() {
 
             @Override
             public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)

--- a/extension/report-generator/src/main/java/org/camunda/bpm/extension/process_test_coverage/util/CoverageReportUtil.java
+++ b/extension/report-generator/src/main/java/org/camunda/bpm/extension/process_test_coverage/util/CoverageReportUtil.java
@@ -79,7 +79,6 @@ public class CoverageReportUtil {
 
     private static void writeToFile(final String filePath, final String json) throws IOException {
       Files.write(Paths.get(filePath), json.getBytes());
-      //Files.writeString(Paths.get(filePath), json);
     }
 
     private static void installReportDependencies(final String reportDirectory) {

--- a/extension/report-generator/src/main/java/org/camunda/bpm/extension/process_test_coverage/util/CoverageReportUtil.java
+++ b/extension/report-generator/src/main/java/org/camunda/bpm/extension/process_test_coverage/util/CoverageReportUtil.java
@@ -78,7 +78,8 @@ public class CoverageReportUtil {
     }
 
     private static void writeToFile(final String filePath, final String json) throws IOException {
-        Files.writeString(Paths.get(filePath), json);
+      Files.write(Paths.get(filePath), json.getBytes());
+      //Files.writeString(Paths.get(filePath), json);
     }
 
     private static void installReportDependencies(final String reportDirectory) {

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
                         <useSystemClassLoader>false</useSystemClassLoader>
                         <shutdown>kill</shutdown>
                         <runOrder>random</runOrder>
-                        <argLine>--illegal-access=permit -Djava.awt.headless=true -XX:+StartAttachListener -Xmx1024m
+                        <argLine>-Djava.awt.headless=true -XX:+StartAttachListener -Xmx1024m
                         </argLine>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Here are all changes required to build the librarry based on Java 8

The CoverageReportUtil used some Java 11 statements.

The surefire plugin set an command line option that is not available in Java 8.